### PR TITLE
fix: Restore missing functional header

### DIFF
--- a/include/_node_parser.h
+++ b/include/_node_parser.h
@@ -8,10 +8,11 @@
 #ifndef __CFG__NODE_PARSER_H_
 #define __CFG__NODE_PARSER_H_
 
-#include <node_parser.h>
 #include <fstream>
+#include <functional>
 #include <vector>
 
+#include <node_parser.h>
 #include <utils.h>
 
 namespace cfg::parser


### PR DESCRIPTION
Although this doesn't seem to be required by Apple Clang++, it is required by g++.